### PR TITLE
Windows fixes and stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Plug 'tamago324/nlsp-settings.nvim'
 
 " Recommend
 Plug 'williamboman/nvim-lsp-installer'
+
+" Optional
+Plug 'rcarriga/nvim-notify'
 ```
 
 ## Getting Started

--- a/doc/nlspsettings.txt
+++ b/doc/nlspsettings.txt
@@ -34,7 +34,7 @@ setup({opts})                                           *nlspsettings.setup()*
 
                       Default: `'~/.config/nvim/nlsp-settings'`
 
-        {local_settigns_root_markers} (optional, string)
+        {local_settigns_root_markers} (optional, table)
                       A list of files and directories to use when looking
                       for the root directory when opening a file with
                       |:NlspLocalConfig|.
@@ -49,6 +49,15 @@ setup({opts})                                           *nlspsettings.setup()*
 
                       Setting this value to true is equal to executing the
                       following code.
+
+        {nvim_notify} (optional, table)
+                      Configuration for nvim-notify integration.
+
+                      Config table:
+                      • `enable` : Enable nvim-notify integration.
+                      • `timeout` : Time to show notification in millisencons.
+
+                      Default: `{ enable = false, timeout = 5000 }`
 
 get_settings({name})                             *nlspsettings.get_settings()*
     Gets the configuration of the specified server.

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -13,11 +13,15 @@ local M = {}
 ---@param level number
 local log = function(message, level)
   local title = 'NLsp Settings'
+  local notify_config = config.get 'nvim_notify'
 
-  if notify then
-    notify(message, level, { title = title })
+  if notify and notify_config and notify_config.enable then
+    notify(message, level, {
+      title = title,
+      timeout = notify_config.timeout
+    })
   else
-    vim.notify(('[%s] '):format(title) .. message, level)
+    vim.notify(('[%s] %s'):format(title, message), level)
   end
 end
 
@@ -50,9 +54,7 @@ local with_server_name = function(bufnr, callback)
   end
 
   if #server_names > 1 then
-    vim.ui.select(server_names, { prompt = 'Select server:' }, function(server_name)
-      callback(server_name)
-    end)
+    vim.ui.select(server_names, { prompt = 'Select server:' }, callback)
   else
     callback(server_names[1])
   end

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -1,7 +1,7 @@
 local config = require 'nlspsettings.config'
 local nlspsettings = require 'nlspsettings'
 local lspconfig = require 'lspconfig'
-local has_notify, notify = pcall(require, 'notify')
+local notify = vim.F.npcall(require, 'notify')
 
 local path = lspconfig.util.path
 local uv = vim.loop
@@ -14,7 +14,7 @@ local M = {}
 local log = function(message, level)
   local title = 'NLsp Settings'
 
-  if has_notify then
+  if notify then
     notify(message, level, { title = title })
   else
     vim.notify(('[%s] '):format(title) .. message, level)

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -1,26 +1,40 @@
-local config = require'nlspsettings.config'
-local nlspsettings = require'nlspsettings'
-local lspconfig_util = require'lspconfig.util'
+local config = require 'nlspsettings.config'
+local nlspsettings = require 'nlspsettings'
+local lspconfig = require 'lspconfig'
+local has_notify, notify = pcall(require, 'notify')
 
-local a = vim.api
+local path = lspconfig.util.path
 local uv = vim.loop
 
 local M = {}
 
+--- Logs a message with the given log level.
+---@param message string
+---@param level number
+local log = function(message, level)
+  local title = 'NLsp Settings'
+
+  if has_notify then
+    notify(message, level, { title = title })
+  else
+    vim.notify(('[%s] '):format(title) .. message, level)
+  end
+end
+
 --- Get the path to the buffer number
----@param bufnr string
+---@param bufnr number?
 ---@return string
 local get_buffer_path = function(bufnr)
   local expr = (bufnr ~= nil and '#' .. bufnr) or '%'
-  return vim.fn.expand(expr..':p')
+  return vim.fn.expand(expr .. ':p')
 end
 
---- Returns the name of the server connected to the current buffer.
----@param bufnr number? buffer number
----@return string server_name
-local get_server_name = function(bufnr)
+--- Calls the callback with the name of the server connected to the given buffer.
+---@param bufnr number?
+---@param callback function
+local with_server_name = function(bufnr, callback)
   vim.validate {
-    bufnr = { bufnr, 'n', true }
+    bufnr = { bufnr, 'n', true },
   }
 
   local server_names = {}
@@ -31,76 +45,71 @@ local get_server_name = function(bufnr)
     end
   end
 
-  if #server_names == 0 then
+  if not next(server_names) then
     return
   end
 
-  local server_name = server_names[1]
   if #server_names > 1 then
-    local list = {}
-    for i, v in ipairs(server_names) do
-      table.insert(list, string.format('%d: %s', i, v))
-    end
-
-    table.insert(list, 1, 'Select server: ')
-    local idx = vim.fn.inputlist(list)
-    if idx == 0 then
-      return
-    end
-    server_name = server_names[idx]
+    vim.ui.select(server_names, { prompt = 'Select server:' }, function(server_name)
+      callback(server_name)
+    end)
+  else
+    callback(server_names[1])
   end
-
-  return server_name
 end
 
 --- open config file
----@param server_name string
 ---@param dir string
+---@param server_name string
 local open_config = function(dir, server_name)
   vim.validate {
     server_name = { server_name, 's' },
-    dir = { dir, 's' }
+    dir = { dir, 's' },
   }
 
-  if vim.fn.isdirectory(dir) == 0 then
-    if vim.fn.confirm(string.format([[Config directory "%s" not exists, create?]], dir), "&Yes\n&No", 1) ~= 1 then
+  if not path.is_dir(dir) then
+    local prompt = ('Config directory %s not exists, create?'):format(dir)
+
+    if vim.fn.confirm(prompt, '&Yes\n&No', 1) ~= 1 then
       return
     end
+
     vim.fn.mkdir(dir, 'p')
   end
 
-  local path = string.format('%s/%s.json', dir, server_name)
+  local filepath = path.join(dir, server_name .. '.json')
 
   -- If the file does not exist, LSP will not be able to complete it, so create it
-  do
-    local stat = uv.fs_stat(path)
-    local exists = not vim.tbl_isempty(stat or {})
-    if not exists then
-      local mode = tonumber('644', 8)
-      local fd = uv.fs_open(path, "w", mode)
-      if not fd then error('Could not create file: ' .. path) end
-      uv.fs_close(fd)
+  if not path.is_file(filepath) then
+    local fd = uv.fs_open(filepath, 'w', 420)
+
+    if not fd then
+      log('Could not create file: ' .. filepath, vim.log.levels.ERROR)
+      return
     end
+
+    uv.fs_close(fd)
   end
 
   local cmd = (vim.api.nvim_buf_get_option(0, 'modified') and 'split') or 'edit'
-  vim.api.nvim_command(string.format([[%s %s]], cmd, path))
+  vim.api.nvim_command(cmd .. ' ' .. filepath)
 end
 
 --- Open a settings file that matches the current buffer
 M.open_buf_config = function()
-  local server_name = get_server_name()
-  if server_name == nil then
-    return
-  end
+  with_server_name(nil, function(server_name)
+    if not server_name then
+      return
+    end
 
-  M.open_config(server_name)
+    M.open_config(server_name)
+  end)
 end
 
 ---Open the settings file for the specified server.
 ---@param server_name string
 M.open_config = function(server_name)
-  open_config(config.get('config_home'), server_name)
+  open_config(config.get 'config_home', server_name)
 end
 
 ---Open the settings file for the specified server.
@@ -111,51 +120,55 @@ M.open_local_config = function(server_name)
     start_path = vim.fn.getcwd()
   end
 
-  local markers = config.get('local_settings_root_markers') or {}
-  local root_dir = lspconfig_util.root_pattern(markers)(start_path)
-  if root_dir == nil then
-    a.nvim_echo({{string.format(' Nlsp[%s][Error] Failed to get root_dir.', server_name), 'ErrorMsg'}}, false, {})
-    return
+  local markers = config.get 'local_settings_root_markers'
+  local root_dir = lspconfig.util.root_pattern(markers)(path.sanitize(start_path))
+
+  if root_dir then
+    open_config(path.join(root_dir:gsub('/$', ''), '.nlsp-settings'), server_name)
+  else
+    log(('[%s] Failed to get root_dir.'):format(server_name), vim.log.levels.ERROR)
   end
-  open_config(string.gsub(root_dir, '/$', '') .. '/.nlsp-settings', server_name)
 end
 
 --- Open a settings file that matches the current buffer
 M.open_local_buf_config = function()
-  local server = get_server_name()
-  if server == nil then
-    return
-  end
+  with_server_name(nil, function(server_name)
+    if server_name == nil then
+      return
+    end
 
-  local client = vim.lsp.get_client_by_id(server.client_id)
-  if client == nil then
-    a.nvim_echo({{string.format(' Nlsp[%s][Error] Failed to get root_dir.', server.name), 'ErrorMsg'}}, false, {})
-    return
-  end
-  local root_dir = client.config.root_dir
+    local clients = vim.tbl_filter(function(server)
+      if server.name == server_name then
+        return server
+      end
+    end, vim.lsp.buf_get_clients())
+    local client = unpack(clients)
 
-  open_config(root_dir .. '/.nlsp-settings', server.name)
+    if client then
+      open_config(path.join(client.config.root_dir, '.nlsp-settings'), server_name)
+    else
+      log(('[%s] Failed to get root_dir.'):format(server_name), vim.log.levels.ERROR)
+    end
+  end)
 end
 
 ---Update the setting values.
 ---@param server_name string
 M.update_settings = function(server_name)
-  vim.cmd [[redraw]]
-  local errors = nlspsettings.update_settings(server_name)
-  if errors then
-    a.nvim_echo({{string.format(' Nlsp[%s][Error] Failed to update the settings.', server_name), 'ErrorMsg'}}, false, {})
+  vim.api.nvim_command 'redraw'
+
+  if nlspsettings.update_settings(server_name) then
+    log(('[%s] Failed to update the settings.'):format(server_name), vim.log.levels.ERROR)
   else
-    a.nvim_echo({{string.format(' Nlsp[%s][Info] Success to update the settings.', server_name), 'Normal'}}, false, {})
+    log(('[%s] Success to update the settings.'):format(server_name), vim.log.levels.INFO)
   end
 end
-
 
 ---What to do when BufWritePost fires
 ---@param afile string
 M._BufWritePost = function(afile)
-  local server_name = string.match(afile, '([^/]+)%.json$')
+  local server_name = path.sanitize(afile):match '([^/]+)%.json$'
   M.update_settings(server_name)
 end
-
 
 return M

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -68,7 +68,7 @@ local open_config = function(dir, server_name)
   }
 
   if not path.is_dir(dir) then
-    local prompt = ('Config directory %s not exists, create?'):format(dir)
+    local prompt = ('Config directory "%s" not exists, create?'):format(path.sanitize(dir))
 
     if vim.fn.confirm(prompt, '&Yes\n&No', 1) ~= 1 then
       return

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -74,7 +74,7 @@ local open_config = function(dir, server_name)
       return
     end
 
-    vim.fn.mkdir(dir, 'p')
+    uv.fs_mkdir(dir, 420)
   end
 
   local filepath = path.join(dir, server_name .. '.json')

--- a/lua/nlspsettings/command.lua
+++ b/lua/nlspsettings/command.lua
@@ -133,7 +133,7 @@ end
 --- Open a settings file that matches the current buffer
 M.open_local_buf_config = function()
   with_server_name(nil, function(server_name)
-    if server_name == nil then
+    if not server_name then
       return
     end
 

--- a/lua/nlspsettings/config.lua
+++ b/lua/nlspsettings/config.lua
@@ -4,6 +4,10 @@ local defaults_values = {
     '.git',
   },
   jsonls_append_default_schemas = false,
+  nvim_notify = {
+    enable = false,
+    timeout = 5000,
+  }
 }
 
 local config = {}

--- a/lua/nlspsettings/config.lua
+++ b/lua/nlspsettings/config.lua
@@ -1,11 +1,10 @@
 local defaults_values = {
-  config_home = vim.fn.stdpath('config') .. '/nlsp-settings',
+  config_home = vim.fn.stdpath 'config' .. '/nlsp-settings',
   local_settings_root_markers = {
     '.git',
   },
-  jsonls_append_default_schemas = false
+  jsonls_append_default_schemas = false,
 }
-
 
 local config = {}
 config.values = vim.deepcopy(defaults_values)
@@ -14,13 +13,13 @@ config.set_default_values = function(opts)
   config.values = vim.tbl_deep_extend('force', defaults_values, opts or {})
 
   -- For an empty table
-  if vim.tbl_isempty(config.values.local_settings_root_markers) then
-    config.values.float = defaults_values.local_settings_root_markers
+  if not next(config.values.local_settings_root_markers) then
+    config.values.local_settings_root_markers = defaults_values.local_settings_root_markers
   end
 end
 
 config.get = function(key)
-  return config.values[key] or nil
+  return config.values[key]
 end
 
 return config

--- a/lua/nlspsettings/jsonls.lua
+++ b/lua/nlspsettings/jsonls.lua
@@ -1,10 +1,9 @@
 local uv = vim.loop
 
-
 local script_abspath = function()
   return debug.getinfo(2, 'S').source:sub(2)
 end
-local _schemas_dir = script_abspath():match('(.*)/lua/nlspsettings/jsonls.lua$') .. '/schemas'
+local _schemas_dir = script_abspath():match '(.*)/lua/nlspsettings/jsonls.lua$' .. '/schemas'
 
 local M = {}
 
@@ -42,7 +41,6 @@ local reset_default_schemas = function()
 end
 reset_default_schemas()
 
-
 --- Return a list of default schemas
 ---@return table
 M.get_default_schemas = function()
@@ -51,19 +49,17 @@ M.get_default_schemas = function()
   for k, v in pairs(default_schemas) do
     table.insert(res, {
       fileMatch = { k .. '.json' },
-      url = v
+      url = v,
     })
   end
 
   return res
 end
 
-
 --- Return the name of a supported server.
 ---@return table
 M.get_langserver_names = function()
   return vim.tbl_keys(default_schemas)
 end
-
 
 return M

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+no_call_parentheses = true


### PR DESCRIPTION
fix(windows): use path.sanitize to handle correctly windows paths with lspconfig
fix(config): config.values.float -> config.values.local_settings_root_markers
fix(core): changed typo err -> err_ in nlspsettings.lua when checking local config errors
feat(log): use nvim-notify if available or vim.notify
feat(selection): use vim.ui.select to select a server
feat(path): use lspconfig.util.path to handle path stuff like is_file, is_dir, etc
feat(array): use next() to check if an array is empty
fix(local-buf-config): `vim.lsp.get_client_by_id(server.client_id)` was used where server is getted from `get_server_name()` so doesn't make sense(because a string does not have the `client_id` property)

[example](https://gyazo.com/d9fc0af97f1278a9b5523c38d65709c5) of `vim.ui.select` with [dressing](https://github.com/stevearc/dressing.nvim)(without dressing looks like before)
[example](https://gyazo.com/0727c87ba66b2a6f8cb17651ade35846) of [nvim-notify](https://github.com/rcarriga/nvim-notify)