### PR TITLE
feat: single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,19 @@ TODO: その他の設定は doc を参照
 
 ### Step3. Write settings
 
-Execute `:NlspConfig sumneko_lua`.  
+Execute `:LspSettings sumneko_lua`.  
 `sumneko_lua.json` will be created under the directory set in `config_home`. Type `<C-x><C-o>`. You should now have jsonls completion enabled.
 
 
 ## Usage
 
-### Commands
+### LspSettings command
 
-* `:NlspConfig [server_name]`:  Open the global settings file for the specified `{server_name}`.
-* `:NlspBufConfig`: Open the global settings file that matches the current buffer.
-* `:NlspLocalConfig [server_name]`: Open the local settings file of the specified `{server_name}` corresponding to the cwd.
-* `:NlspLocalBufConfig`:  Open the local settings file of the server corresponding to the current buffer.
-* `:NlspUpdateSettings [server_name]`: Update the setting values for the specified `{server_name}`.
+* `:LspSettings [server_name]`:  Open the global settings file for the specified `{server_name}`.
+* `:LspSettings buffer`: Open the global settings file that matches the current buffer.
+* `:LspSettings local [server_name]`: Open the local settings file of the specified `{server_name}` corresponding to the cwd.
+* `:LspSettings local buffer` or `LspSettings buffer local`:  Open the local settings file of the server corresponding to the current buffer.
+* `:LspSettings update [server_name]`: Update the setting values for the specified `{server_name}`.
 
 For a list of language servers that have JSON Schema, see [here](schemas/README.md).
 
@@ -103,8 +103,8 @@ For a list of language servers that have JSON Schema, see [here](schemas/README.
 
 You can create a settings file for each project with the following command.
 
-* `:NlspLocalConfig [server_name]`.
-* `:NlspUpdateSettings [server_name]`
+* `:LspSettings local [server_name]`.
+* `:LspSettings update [server_name]`
 
 The settings file will be created in `{project_path}/.nlsp-settings/{server_name}.json`.
 

--- a/doc/nlspsettings.txt
+++ b/doc/nlspsettings.txt
@@ -40,7 +40,7 @@ setup({opts})                                           *nlspsettings.setup()*
 
         {local_settigns_root_markers} (optional, table)
             A list of files and directories to use when looking for the
-            root directory when opening a file with |:NlspLocalConfig|.
+            root directory when opening a file with `:LspSettings local` .
 
             Default: `{ '.git' }`
 
@@ -58,8 +58,22 @@ setup({opts})                                           *nlspsettings.setup()*
 
             Default: `"json"`
 
+        {ignored_servers} (optional, table)
+            List of server names that should not appear in the server
+            choices when running `:LspSettings buffer` and
+            `:LspSettings local buffer` if more than one server is
+            connected to the current buffer.
+
+            Default: `{}`
+
         {append_default_schemas} (optional, boolean)
             Add defaults to the language server schemas in the |loader|.
+
+            Default: `false`
+
+        {open_strictly} (optional, boolean)
+            Determines if server given from command line should have a
+            config in `nvim-lspconfig`.
 
             Default: `false`
 
@@ -94,36 +108,27 @@ get_default_schemas()                  *nlspsettings.yaml.get_default_schemas()*
 
 
 ------------------------------------------------------------------------------
-COMMANDS                                              *nlsp-settings-commands*
+COMMANDS                                    *:LspSettings* *nlspsettings-commands*
 
-:NlspConfig {server_name}                                        *:NlspConfig*
+:LspSettings {server_name}
     Open the settings file for the specified {server_name}.
 
-:NlspBufConfig                                                *:NlspBufConfig*
+:LspSettings buffer
     Open a settings file that matches the current buffer.
 
-:NlspLocalConfig {server_name}                              *:NlspLocalConfig*
+:LspSettings local {server_name}
     Open the local settings file of the specified {server_name}
     corresponding to the cwd.
-    NOTE: Local version of |:NlspConfig|
+    NOTE: Local version of `:LspSettings`
 
-:NlspLocalBufConfig                                      *:NlspLocalBufConfig*
+:LspSettings buffer local
+:LspSettings local buffer
     Open the local settings file of the server corresponding to the
     current buffer.
-    NOTE: Local version of |:NlspBufConfig|
+    NOTE: Local version of `:LspSettings buffer`
 
-:NlspUpdateSettings {server_name}                        *:NlspUpdateSettings*
+:LspSettings update {server_name}
     Update the setting values for the specified {server_name}.
-
-
-------------------------------------------------------------------------------
-KEYMAPPINGS                                        *nlsp-settings-keymappings*
-
-n <Plug>(nlsp-buf-config)                            *<Plug>(nlsp-buf-config)*
-    |:NlspBufConfig|
-
-n <Plug>(nlsp-local-buf-config)                *<Plug>(nlsp-local-buf-config)*
-    |:NlspLocalBufConfig|
 
 
 ==============================================================================

--- a/lua/nlspsettings.lua
+++ b/lua/nlspsettings.lua
@@ -1,6 +1,7 @@
 local config = require 'nlspsettings.config'
 local lspconfig = require 'lspconfig'
 local utils = require 'nlspsettings.utils'
+local lspconfig_util = require 'lspconfig.util'
 
 local uv = vim.loop
 
@@ -238,12 +239,12 @@ end
 local setup_autocmds = function()
   local conf = config.get()
   local patterns = {
-    string.format('*/%s/*.%s', conf.config_home:match '[^/]+$', loader.file_ext),
-    string.format('*/%s/*.%s', conf.local_settings_dir, loader.file_ext),
+    string.format('*/%s/*.%s', lspconfig_util.path.sanitize(conf.config_home):match '[^/]+$', loader.file_ext),
+    string.format('*/%s/*.%s', lspconfig_util.path.sanitize(conf.local_settings_dir), loader.file_ext),
   }
   local pattern = table.concat(patterns, ',')
 
-  vim.cmd [[augroup NlspSettings]]
+  vim.cmd [[augroup LspSettings]]
   vim.cmd [[  autocmd!]]
   vim.cmd(
     ([[  autocmd BufWritePost %s lua require'nlspsettings.command'._BufWritePost(vim.fn.expand('<afile>'))]]):format(

--- a/lua/nlspsettings/command/completion.lua
+++ b/lua/nlspsettings/command/completion.lua
@@ -1,0 +1,73 @@
+local schemas = require 'nlspsettings.schemas'
+local parser = require 'nlspsettings.command.parser'
+
+--- Get the flags to implement in the completion
+---@param cmdline string
+---@return string[], boolean
+local get_flags = function(cmdline)
+  local result = {}
+  local server = true
+  local matched = false
+  local unique
+
+  for flag, data in pairs(parser.Flags) do
+    if data.unique then
+      unique = flag
+    elseif cmdline:match(flag) then
+      if not data.server then
+        server = false
+      end
+      matched = true
+    else
+      table.insert(result, flag)
+    end
+  end
+
+  if matched then
+    return result, server
+  elseif cmdline:match(unique) then
+    return {}, server
+  end
+
+  return vim.tbl_keys(parser.Flags), server
+end
+
+--- Get the servers supported
+---@param cmdline string
+---@return string[], boolean
+local get_servers = function(cmdline)
+  local result = {}
+  for _, server in ipairs(schemas.get_langserver_names()) do
+    if cmdline:match(server) then
+      return {}, true
+    end
+    table.insert(result, server)
+  end
+  return result, false
+end
+
+local M = {}
+
+--- Returns the smarter completion list
+---@param _ string
+---@param cmdline string
+---@return string
+M.complete = function(_, cmdline)
+  local items = {}
+  local flags, requires_server = get_flags(cmdline)
+  local servers, server_found = get_servers(cmdline)
+
+  if server_found then
+    return ''
+  end
+
+  if requires_server then
+    vim.list_extend(items, servers)
+  end
+
+  vim.list_extend(items, flags)
+
+  return table.concat(items, '\n')
+end
+
+return M

--- a/lua/nlspsettings/command/parser.lua
+++ b/lua/nlspsettings/command/parser.lua
@@ -1,0 +1,175 @@
+local schemas = require 'nlspsettings.schemas'
+local config = require 'nlspsettings.config'
+
+---@class nlspsettings.command.parser.flag
+---@field server boolean
+---@field unique boolean
+
+---@class nlspsettings.command.parser.FLAGS
+---@field buffer nlspsettings.command.parser.flag
+---@field local nlspsettings.command.parser.flag
+---@field update nlspsettings.command.parser.flag
+local FLAGS = {
+  ['buffer'] = {
+    server = false,
+    unique = false,
+  },
+  ['local'] = {
+    server = true,
+    unique = false,
+  },
+  ['update'] = {
+    server = true,
+    unique = true,
+  },
+}
+
+---@class nlspsettings.command.parser.ACTIONS
+---@field OPEN string
+---@field OPEN_BUFFER string
+---@field OPEN_LOCAL string
+---@field OPEN_LOCAL_BUFFER string
+---@field UPDATE string
+local ACTIONS = {
+  OPEN = 'open',
+  OPEN_BUFFER = 'open_buffer',
+  OPEN_LOCAL = 'open_local',
+  OPEN_LOCAL_BUFFER = 'open_local_buffer',
+  UPDATE = 'update',
+}
+
+---@class nlspsettings.command.parser.ERRORS
+---@field NOT_SERVER string
+---@field NOT_FLAG string
+---@field FLAG_REPEATED string
+---@field NOT_ALLOWED string
+---@field SERVER_REQUIRED string
+---@field EMPTY string
+local ERRORS = {
+  NOT_SERVER = '`%s` is not a valid server',
+  NOT_FLAG = '`%s` is not a valid flag',
+  FLAG_REPEATED = '`%s` is repeated',
+  NOT_ALLOWED = '`%s` does not allow `%s` flag',
+  SERVER_REQUIRED = '`%s` requires a server',
+  EMPTY = 'argument #%i is empty',
+}
+
+--- Creates a parser from list
+---@param list table
+---@param arg string
+---@param err string
+local from_list = function(list, arg, err)
+  for _, item in ipairs(list) do
+    if item == arg then
+      return arg
+    end
+  end
+  error(err:format(arg))
+end
+
+--- Parses a flag
+---@param arg string
+---@return string
+local parse_flag = function(arg)
+  return from_list(vim.tbl_keys(FLAGS), arg, ERRORS.NOT_FLAG)
+end
+
+--- Parses a server
+---@param arg string
+---@return string
+local parse_server = function(arg)
+  if config.get().open_strictly then
+    return from_list(schemas.get_langserver_names(), arg, ERRORS.NOT_SERVER)
+  end
+  return arg
+end
+
+local M = {
+  Flags = FLAGS,
+  Actions = ACTIONS,
+}
+
+---@class nlspsettings.command.parser.result
+---@field action string
+---@field server string?
+
+--- Parses a table or a string
+---@param args table|string
+---@return nlspsettings.command.parser.result?
+M.parse = function(args)
+  local flags = {}
+  local context = {
+    requires_server = true,
+    unique_flag = nil,
+    last_flag = nil,
+  }
+
+  if type(args) == 'string' then
+    args = vim.split(args, ' ')
+  end
+
+  local function process_flag(flag)
+    if flags[flag] then
+      error(ERRORS.FLAG_REPEATED:format(flag))
+    end
+
+    if context.unique_flag then
+      error(ERRORS.NOT_ALLOWED:format(context.unique_flag, flag))
+    elseif FLAGS[flag].unique and context.last_flag then
+      error(ERRORS.NOT_ALLOWED:format(context.last_flag, flag))
+    end
+
+    if not FLAGS[flag].server then
+      context.requires_server = nil
+    end
+
+    flags[flag] = true
+    context.unique_flag = FLAGS[flag].unique and flag
+    context.last_flag = flag
+  end
+
+  if vim.tbl_isempty(args) then
+    error(ERRORS.EMPTY:format(1))
+  end
+
+  for index, arg in ipairs(args) do
+    if arg == '' then
+      error(ERRORS.EMPTY:format(index))
+    end
+
+    if index == #args then
+      local success, flag = pcall(parse_flag, arg)
+      if success then
+        process_flag(flag)
+      elseif not context.requires_server then
+        error(flag)
+      end
+
+      if success and context.requires_server and index == 1 then
+        error(ERRORS.SERVER_REQUIRED:format(flag))
+      end
+
+      break
+    end
+
+    process_flag(parse_flag(arg))
+  end
+
+  local action = ACTIONS.OPEN
+  if flags['local'] and flags['buffer'] then
+    action = ACTIONS.OPEN_LOCAL_BUFFER
+  elseif flags['local'] then
+    action = ACTIONS.OPEN_LOCAL
+  elseif flags['buffer'] then
+    action = ACTIONS.OPEN_BUFFER
+  elseif flags['update'] then
+    action = ACTIONS.UPDATE
+  end
+
+  return {
+    action = action,
+    server = context.requires_server and parse_server(args[#args]),
+  }
+end
+
+return M

--- a/lua/nlspsettings/config.lua
+++ b/lua/nlspsettings/config.lua
@@ -4,7 +4,9 @@ local defaults_values = {
   local_settings_root_markers = {
     '.git',
   },
+  ignored_servers = {},
   append_default_schemas = false,
+  open_strictly = false,
   nvim_notify = {
     enable = false,
     timeout = 5000,
@@ -20,7 +22,9 @@ local config = {}
 ---@field config_home string:nil
 ---@field local_settings_dir string
 ---@field local_settings_root_markers string[]
+---@field ignored_servers string[]
 ---@field append_default_schemas boolean
+---@field open_strictly boolean
 ---@field nvim_notify nlspsettings.config.values.nvim_notify
 ---@field loader '"json"' | '"yaml"'
 config.values = vim.deepcopy(defaults_values)

--- a/lua/nlspsettings/deprecated.lua
+++ b/lua/nlspsettings/deprecated.lua
@@ -1,0 +1,25 @@
+local log = require 'nlspsettings.log'
+
+local M = {}
+
+M.open = function()
+  log.warn ':NlspConfig has been removed in favor of :LspSettings {server_name}'
+end
+
+M.open_local = function()
+  log.warn ':NlspLocalConfig has been removed in favor of :LspSettings local {server_name}'
+end
+
+M.open_buffer = function()
+  log.warn ':NlspBufConfig has been removed in favor of :LspSettings buffer'
+end
+
+M.open_local_buffer = function()
+  log.warn ':NlspLocalBufConfig has been removed in favor of :LspSettings buffer local'
+end
+
+M.update = function()
+  log.warn ':NlspUpdateSettings has been removed in favor of :LspSettings update {server_name}'
+end
+
+return M

--- a/lua/nlspsettings/log.lua
+++ b/lua/nlspsettings/log.lua
@@ -1,23 +1,60 @@
 local has_notify, notify = pcall(require, 'notify')
 local config = require 'nlspsettings.config'
 
-local M = {}
+local TITLE = 'Lsp Settings'
+
+--- Checks if can se nvim-notify integration
+---@return
+local use_nvim_notify = function()
+  local notify_config = config.get().nvim_notify
+  return has_notify and notify_config and notify_config.enable
+end
 
 --- Logs a message with the given log level.
 ---@param message string
 ---@param level number
-M.log = function(message, level)
-  local title = 'NLsp Settings'
-  local notify_config = config.get().nvim_notify
-
-  if notify and notify_config and notify_config.enable then
+local log = function(message, level)
+  if use_nvim_notify() then
     notify(message, level, {
-      title = title,
-      timeout = notify_config.timeout,
+      title = TITLE,
+      timeout = config.get().nvim_notify.timeout,
     })
   else
-    vim.notify(('[%s] %s'):format(title, message), level)
+    vim.notify(('[%s] %s'):format(TITLE, message), level)
   end
 end
+
+--- Logs a message once with the given log level.
+---@param message string
+---@param level number
+local log_once = function(message, level)
+  -- users of nvim-notify may have `vim.notify = require("notify")`
+  -- vim.notify_once uses vim.notify
+  if use_nvim_notify() and vim.notify == notify then
+    vim.notify_once(message, level, {
+      title = TITLE,
+      timeout = config.get().nvim_notify.timeout,
+    })
+  else
+    vim.notify_once(('[%s] %s'):format(TITLE, message), level)
+  end
+end
+
+--- Creates a logger from the given level.
+---@param level string
+local create_level = function(level)
+  return function(message, once)
+    if once then
+      return log_once(message, level)
+    end
+    log(message, level)
+  end
+end
+
+local M = {}
+
+M.info = create_level(vim.log.levels.INFO)
+M.warn = create_level(vim.log.levels.WARN)
+M.error = create_level(vim.log.levels.ERROR)
 
 return M

--- a/lua/nlspsettings/utils.lua
+++ b/lua/nlspsettings/utils.lua
@@ -1,3 +1,5 @@
+local log = require 'nlspsettings.log'
+
 ---@param t table
 ---@return boolean
 local is_table = function(t)
@@ -32,7 +34,7 @@ local extend = function(t1, t2)
   if (vim.tbl_islist(t1) and is_table(t2)) or (is_table(t1) and vim.tbl_islist(t2)) then
     -- list + table
     -- table + list
-    vim.notify_once('[Nlspsettings] Cannot merge list and table', vim.log.levels.WARN, {})
+    log.warn('Cannot merge list and table', true)
   end
   return t1
 end

--- a/plugin/nlspsetting.vim
+++ b/plugin/nlspsetting.vim
@@ -3,18 +3,16 @@ if exists('g:loaded_nlspsettings')
 endif
 let g:loaded_nlspsettings = 1
 
+command! -nargs=* -complete=custom,v:lua.require'nlspsettings.command.completion'.complete
+            \ LspSettings lua require("nlspsettings.command")._command(<f-args>)
+
+" deprecated
 function! s:complete(arg, line, pos) abort
   return join(luaeval('require("nlspsettings.schemas").get_langserver_names()'), "\n")
 endfunction
 
-command! -nargs=1 -complete=custom,s:complete NlspConfig lua require('nlspsettings.command').open_config(<f-args>)
-command! -nargs=1 -complete=custom,s:complete NlspLocalConfig lua require('nlspsettings.command').open_local_config(<f-args>)
-
-command! -nargs=0 NlspBufConfig lua require('nlspsettings.command').open_buf_config()
-command! -nargs=0 NlspLocalBufConfig lua require('nlspsettings.command').open_local_buf_config()
-
-command! -nargs=1 -complete=custom,s:complete NlspUpdateSettings lua require('nlspsettings.command').update_settings(<f-args>)
-
-nnoremap <Plug>(nlsp-buf-config) <Cmd>lua require('nlspsettings.command').open_buf_config()<CR>
-nnoremap <Plug>(nlsp-local-buf-config) <Cmd>lua require('nlspsettings.command').open_local_buf_config()<CR>
-
+command! -nargs=1 -complete=custom,s:complete NlspConfig lua require('nlspsettings.deprecated').open()
+command! -nargs=1 -complete=custom,s:complete NlspLocalConfig lua require('nlspsettings.deprecated').open_local()
+command! -nargs=0 NlspBufConfig lua require('nlspsettings.deprecated').open_buffer()
+command! -nargs=0 NlspLocalBufConfig lua require('nlspsettings.deprecated').open_local_buffer()
+command! -nargs=1 -complete=custom,s:complete NlspUpdateSettings lua require('nlspsettings.deprecated').update()


### PR DESCRIPTION
Hello.
### Features
* [smart completion](https://gyazo.com/4af8708947fc7b099b0c1e3351a04e15)
* refactor of `vim.notify_once`(internally uses `vim.notify`) usage
* `ignored_servers` config option, people may use [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) or [emf-langserver](https://github.com/mattn/efm-langserver) to get diagnostic from linters, or use code formatters. These doesn't need settings(at least null-ls)
* `open_strictly` just opens settings that are supported(checking schemas and `lspconfig.configs`)
* single command(`:help :LspSettings`)

### Questions
#### ¿Why I changed `NlspConfig` -> `LspSettings`?
More consistency and "normal" completion matching with other `^Lsp` commands, also I changed `Config` to `Settings` to avoid confusions with `nvim-lspconfig`.
![image](https://user-images.githubusercontent.com/70210066/162653850-f4621a76-34d0-4e63-9c7b-ec0cdb5ebaca.png)
yeah, this is a breaking change, but if you like I can put the old commands as deprecated.
#### ¿Why having a single command instead of multiple commands?
Some plugins are implementing this([neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim), [gitsigns](https://github.com/lewis6991/gitsigns.nvim)) and looks more cleaner.

------
feedback is appreciated and open to suggestions! 👍