### PR TITLE
Open configs with tab

### DIFF
--- a/lua/nlspsettings/command/init.lua
+++ b/lua/nlspsettings/command/init.lua
@@ -81,8 +81,7 @@ local open = function(dir, server_name)
     uv.fs_close(fd)
   end
 
-  local cmd = (vim.api.nvim_buf_get_option(0, 'modified') and 'split') or 'edit'
-  vim.api.nvim_command(cmd .. ' ' .. filepath)
+  vim.cmd(string.format('tabnew %s', filepath))
 end
 
 --- Open a settings file that matches the current buffer


### PR DESCRIPTION
People usually update the configs with save and quit (:wq). This may accidentally close nvim and lose all buffers if they open configs in an unmodified file. If the config is opened in new tab, quit only applies to the tab instead of nvim.