### PR TITLE
Rename local_settings_root_makers to local_settings_root_markers_fallback and use lspconfig.<server_name>.get_root_dir instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ local nlspsettings = require("nlspsettings")
 nlspsettings.setup({
   config_home = vim.fn.stdpath('config') .. '/nlsp-settings',
   local_settings_dir = ".nlsp-settings",
-  local_settings_root_markers = { '.git' },
+  local_settings_root_markers_fallback = { '.git' },
   append_default_schemas = true
   loader = 'json'
 })

--- a/doc/nlspsettings.txt
+++ b/doc/nlspsettings.txt
@@ -38,9 +38,10 @@ setup({opts})                                           *nlspsettings.setup()*
 
             Default: `'.nlsp-settings'`
 
-        {local_settigns_root_markers} (optional, table)
+        {local_settigns_root_markers_fallback} (optional, table)
             A list of files and directories to use when looking for the
-            root directory when opening a file with `:LspSettings local` .
+            root directory when opening a file with `:LspSettings local`  if
+            not found by `nvim-lspconfig`.
 
             Default: `{ '.git' }`
 

--- a/lua/nlspsettings/command/init.lua
+++ b/lua/nlspsettings/command/init.lua
@@ -111,8 +111,15 @@ M.open_local_config = function(server_name)
   end
 
   local conf = config.get()
-  local markers = conf.local_settings_root_markers
-  local root_dir = lspconfig.util.root_pattern(markers)(path.sanitize(start_path))
+  local root_dir
+  if lspconfig[server_name] then
+    root_dir = lspconfig[server_name].get_root_dir(path.sanitize(start_path))
+  end
+
+  if not root_dir then
+    local markers = conf.local_settings_root_markers_fallback
+    root_dir = lspconfig.util.root_pattern(markers)(path.sanitize(start_path))
+  end
 
   if root_dir then
     open(path.join(root_dir:gsub('/$', ''), conf.local_settings_dir), server_name)

--- a/lua/nlspsettings/config.lua
+++ b/lua/nlspsettings/config.lua
@@ -1,7 +1,7 @@
 local defaults_values = {
   config_home = vim.fn.stdpath 'config' .. '/nlsp-settings',
   local_settings_dir = '.nlsp-settings',
-  local_settings_root_markers = {
+  local_settings_root_markers_fallback = {
     '.git',
   },
   ignored_servers = {},
@@ -21,7 +21,7 @@ local config = {}
 ---@class nlspsettings.config.values
 ---@field config_home string:nil
 ---@field local_settings_dir string
----@field local_settings_root_markers string[]
+---@field local_settings_root_markers_fallback string[]
 ---@field ignored_servers string[]
 ---@field append_default_schemas boolean
 ---@field open_strictly boolean
@@ -37,8 +37,8 @@ config.set_default_values = function(opts)
   config.values = vim.tbl_deep_extend('force', defaults_values, opts or {})
 
   -- For an empty table
-  if not next(config.values.local_settings_root_markers) then
-    config.values.local_settings_root_markers = defaults_values.local_settings_root_markers
+  if not next(config.values.local_settings_root_markers_fallback) then
+    config.values.local_settings_root_markers_fallback = defaults_values.local_settings_root_markers_fallback
   end
 end
 

--- a/lua/nlspsettings/config.lua
+++ b/lua/nlspsettings/config.lua
@@ -3,6 +3,7 @@ local defaults_values = {
   local_settings_dir = '.nlsp-settings',
   local_settings_root_markers_fallback = {
     '.git',
+    '.nlsp-settings',
   },
   ignored_servers = {},
   append_default_schemas = false,


### PR DESCRIPTION
I was working on a rust project and I noticed that root for the package was wrong because of "manual" root deduction.
Instead of using root markers I'm using the builtin root finder in lspconfig that you are already using and root markers as a fallback, so I renamed variable configuration to better represent it.

Nice work btw 😃