### PR TITLE
Provide a fallback in a case where `servers[server_name]` is `nil`

### DIFF
--- a/lua/nlspsettings.lua
+++ b/lua/nlspsettings.lua
@@ -124,8 +124,8 @@ local get_settings = function(root_dir, server_name)
   local local_settings, err = load(
     string.format('%s/%s/%s.%s', root_dir, conf.local_settings_dir, server_name, loader.file_ext)
   )
-  local global_settings = servers[server_name].global_settings or {}
-  local conf_settings = servers[server_name].conf_settings or {}
+  local global_settings = (servers[server_name] and servers[server_name].global_settings) or {}
+  local conf_settings = (servers[server_name] and servers[server_name].conf_settings) or {}
 
   -- Priority:
   --   1. local settings


### PR DESCRIPTION
Currently, if the global variable [`servers`](https://github.com/tamago324/nlsp-settings.nvim/blob/b4f6c8e807ddc12483abebdd53c3e0b5504f7ecd/lua/nlspsettings.lua#L15) is empty (which seems to be the case if there are no `global_settings` and `conf_settings`), the first check for [`server[server_name]`](https://github.com/tamago324/nlsp-settings.nvim/blob/b4f6c8e807ddc12483abebdd53c3e0b5504f7ecd/lua/nlspsettings.lua#L127) will silently fail, preventing the config from loading.

This PR adds a fallback for such a case.