### PR TITLE
refactor: replace get_active_clients() with get_clients()

### DIFF
--- a/lua/nlspsettings.lua
+++ b/lua/nlspsettings.lua
@@ -177,7 +177,7 @@ M.update_settings = function(server_name)
     server_name = { server_name, 's' },
   }
 
-  if #vim.lsp.get_active_clients() == 0 then
+  if #utils.get_clients() == 0 then
     -- on_new_config() が呼ばれたときに読むから、設定ファイルを読む必要はない
     return false
   end
@@ -193,7 +193,7 @@ M.update_settings = function(server_name)
   local errors = false
 
   -- server_name のすべてのクライアントの設定を更新する
-  for _, client in ipairs(vim.lsp.get_active_clients()) do
+  for _, client in ipairs(utils.get_clients()) do
     if client.name == server_name then
       -- 設定ファイルの設定と setup() の設定をマージする
       -- 各クライアントの設定を読み込みたいため、ループの中で読み込む

--- a/lua/nlspsettings/utils.lua
+++ b/lua/nlspsettings/utils.lua
@@ -39,6 +39,18 @@ local extend = function(t1, t2)
   return t1
 end
 
+
+--- Get active clients.
+local get_clients = function()
+  if vim.version().major == 0 and vim.version().minor <= 9 then
+    -- DEPRECATED IN 0.10
+    return vim.lsp.get_active_clients()
+  else
+    return vim.lsp.get_clients()
+  end
+end
+
 return {
   extend = extend,
+  get_clients = get_clients
 }


### PR DESCRIPTION
fix #45

`get_active_clients()` has been deprecated since Neovim 0.10.0.
Replaced it with `get_clients()` to ensure compatibility with newer versions.